### PR TITLE
Fix training/validation dataset split

### DIFF
--- a/DeepCycle.py
+++ b/DeepCycle.py
@@ -415,12 +415,13 @@ print("[Model input shape]:", input_shape)
 
 #BUILD THE INPUT DATASET OBJECTS
 e_dataset = tf.data.Dataset.from_tensor_slices((np_data,angles)).shuffle(1000).batch(BATCH_SIZE)
-eval_e_dataset = e_dataset.take(n_cells_to_validation)
-train_e_dataset = e_dataset.skip(n_cells_to_validation)
+n_batches_to_validation = math.ceil(len(e_dataset)*fraction_of_cells_to_validation)
+eval_e_dataset = e_dataset.take(n_batches_to_validation)
+train_e_dataset = e_dataset.skip(n_batches_to_validation)
 
 ae_dataset = tf.data.Dataset.from_tensor_slices((np_data,np_data)).shuffle(1000).batch(BATCH_SIZE)
-eval_ae_dataset = ae_dataset.take(n_cells_to_validation)
-train_ae_dataset = ae_dataset.skip(n_cells_to_validation)
+eval_ae_dataset = ae_dataset.take(n_batches_to_validation)
+train_ae_dataset = ae_dataset.skip(n_batches_to_validation)
 
 #FUNCTION TO PLOT THE TRAINING
 def plot_training(fit):


### PR DESCRIPTION
Hi Andrea,

I was looking at your code and it seems to me that the training and validation datasets are assigned incorrectly. For example, using the mESC dataset and default parameters, `n_cells_to_validation = 958` and hence the code assigns 958 batches to the `eval_e_dataset` and only 170 batches to `train_e_dataset`, whereas using the original fraction (17 %) it should be 192 batches for validation and 936 for training accordingly? I added a minimal change to resolve this. Maybe I misunderstood something though, let me know if that's the case!